### PR TITLE
Update jenkins to weekly 2.489

### DIFF
--- a/jenkins/versions.json
+++ b/jenkins/versions.json
@@ -4,8 +4,8 @@
     "lts"
   ],
   "weekly": {
-    "sha256": "74111bf3ce1216f7f8356c2cef22b854d099a5aef08b6d5ca8b1f6af0b86d42d",
-    "version": "2.489",
+    "sha256": "2985b8882ec62a9e6cdfc0d9e43c123ea56da536c6c0b3e88b661e7a9b1fdb9b",
+    "version": "2.490",
     "repo": "https://pkg.jenkins.io/debian"
   },
   "lts": {

--- a/jenkins/versions.json
+++ b/jenkins/versions.json
@@ -4,8 +4,8 @@
     "lts"
   ],
   "weekly": {
-    "sha256": "2985b8882ec62a9e6cdfc0d9e43c123ea56da536c6c0b3e88b661e7a9b1fdb9b",
-    "version": "2.490",
+    "sha256": "ff376aa7f9735fa6d4ed30b6909f79fadfa21e02c36950b879dca8377c9eceba",
+    "version": "2.491",
     "repo": "https://pkg.jenkins.io/debian"
   },
   "lts": {

--- a/jenkins/versions.json
+++ b/jenkins/versions.json
@@ -4,8 +4,8 @@
     "lts"
   ],
   "weekly": {
-    "sha256": "d8f539026aedcffa7c410792b16c7b9be64b73d23035322b84d9818b7d0c39c3",
-    "version": "2.488",
+    "sha256": "74111bf3ce1216f7f8356c2cef22b854d099a5aef08b6d5ca8b1f6af0b86d42d",
+    "version": "2.489",
     "repo": "https://pkg.jenkins.io/debian"
   },
   "lts": {

--- a/jenkins/versions.json
+++ b/jenkins/versions.json
@@ -4,8 +4,8 @@
     "lts"
   ],
   "weekly": {
-    "sha256": "ff376aa7f9735fa6d4ed30b6909f79fadfa21e02c36950b879dca8377c9eceba",
-    "version": "2.491",
+    "sha256": "7abf13214f1cd5520e143c7d2a3cd81c8c3f48de6738233166f8a948173100b5",
+    "version": "2.492",
     "repo": "https://pkg.jenkins.io/debian"
   },
   "lts": {

--- a/jenkins/weekly/Dockerfile
+++ b/jenkins/weekly/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 
 RUN echo 'deb [ signed-by=/etc/apt/keyrings/jenkins.gpg.asc ] https://pkg.jenkins.io/debian binary/' > /etc/apt/sources.list.d/jenkins.list
 
-ENV JENKINS_VERSION 2.490
+ENV JENKINS_VERSION 2.491
 
 RUN set -eux; \
 	apt-get update; \

--- a/jenkins/weekly/Dockerfile
+++ b/jenkins/weekly/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 
 RUN echo 'deb [ signed-by=/etc/apt/keyrings/jenkins.gpg.asc ] https://pkg.jenkins.io/debian binary/' > /etc/apt/sources.list.d/jenkins.list
 
-ENV JENKINS_VERSION 2.491
+ENV JENKINS_VERSION 2.492
 
 RUN set -eux; \
 	apt-get update; \

--- a/jenkins/weekly/Dockerfile
+++ b/jenkins/weekly/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 
 RUN echo 'deb [ signed-by=/etc/apt/keyrings/jenkins.gpg.asc ] https://pkg.jenkins.io/debian binary/' > /etc/apt/sources.list.d/jenkins.list
 
-ENV JENKINS_VERSION 2.489
+ENV JENKINS_VERSION 2.490
 
 RUN set -eux; \
 	apt-get update; \

--- a/jenkins/weekly/Dockerfile
+++ b/jenkins/weekly/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 
 RUN echo 'deb [ signed-by=/etc/apt/keyrings/jenkins.gpg.asc ] https://pkg.jenkins.io/debian binary/' > /etc/apt/sources.list.d/jenkins.list
 
-ENV JENKINS_VERSION 2.488
+ENV JENKINS_VERSION 2.489
 
 RUN set -eux; \
 	apt-get update; \


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

## Summary by Sourcery

Build:
- Update Jenkins version in Dockerfile from 2.488 to 2.489.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Jenkins version to 2.492.
- **Bug Fixes**
	- Corrected SHA256 checksum for the weekly variant.
- **Chores**
	- Updated Dockerfile to reflect the new Jenkins version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->